### PR TITLE
Updated samtools in Docker and optimized I/O and pipelining in case WDL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,36 @@
 FROM condaforge/mambaforge:22.11.1-4 as conda
 
-ADD . /kage-lite
-WORKDIR /kage-lite
-
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     build-essential \
-    samtools \
     tabix \
     bcftools \
-    zlib1g-dev && \
-    apt-get -y clean  && \
-    apt-get -y autoclean  && \
+    autoconf \
+    zlib1g-dev \
+    libncurses-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libcurl4 \
+    libcrypto++6 && \
+    apt-get -y clean && \
+    apt-get -y autoclean && \
     apt-get -y autoremove
+
+RUN mkdir /samtools
+WORKDIR /samtools
+RUN wget https://github.com/samtools/samtools/releases/download/1.19.2/samtools-1.19.2.tar.bz2 && \
+    bzip2 -d samtools-1.19.2.tar.bz2 && \
+    tar -xvf samtools-1.19.2.tar && \
+    cd samtools-1.19.2 && \
+    autoheader && \
+    autoconf -Wno-syntax && \
+    ./configure && \
+    make && \
+    make install
+
+ADD . /kage-lite
+WORKDIR /kage-lite
 
 RUN pip install numpy==1.23.5 scipy==1.10.0 dill==0.3.6 pandas==2.1.1 truvari==4.1.0 scikit-learn==1.3.1 matplotlib==3.8.0 pytest==8.0.0
 RUN pip install -e shared_memory_wrapper/ -e obgraph/ -e graph_kmer_index/ -e kmer_mapper/ -e kage/ -e lite_utils/

--- a/kmer_mapper/kmer_mapper/command_line_interface.py
+++ b/kmer_mapper/kmer_mapper/command_line_interface.py
@@ -129,7 +129,8 @@ def map_bnp(args):
     np.save(args.output_file, node_counts)
     logging.info("Saved node counts to %s.npy" % args.output_file)
     logging.info("Spent %.3f sec in total mapping kmers using %d threads" % (time.perf_counter()-start_time, args.n_threads))
-    remove_shared_memory_in_session()
+    file.close()
+    logging.info("Closed %s" % file)
 
 
 def run_argument_parser(args):
@@ -168,5 +169,3 @@ def run_argument_parser(args):
 
     args = parser.parse_args(args)
     args.func(args)
-
-    remove_shared_memory_in_session()

--- a/shared_memory_wrapper/shared_memory_wrapper/shared_memory.py
+++ b/shared_memory_wrapper/shared_memory_wrapper/shared_memory.py
@@ -390,9 +390,10 @@ def remove_shared_memory(name, limit_to_session=False):
         if m.startswith(name + "__") or m.startswith(name + "-") or m == name:
             try:
                 sa.delete(m)
+                logging.debug("Deleted %s" % m)
                 n_deleted += 1
             except FileNotFoundError:
-                logging.debug("Did not delete %s" % m)
+                logging.debug("Did not find %s for deletion" % m)
                 continue
             if m in SHARED_MEMORIES_IN_SESSION:
                 SHARED_MEMORIES_IN_SESSION.remove(m)
@@ -406,6 +407,7 @@ def remove_shared_memory(name, limit_to_session=False):
         file = name + ".npz"
         if os.path.exists(file):
             os.remove(file)
+            logging.debug("Deleted %s" % file)
 
         if name in TMP_FILES_IN_SESSION:
             TMP_FILES_IN_SESSION.remove(name)
@@ -413,7 +415,7 @@ def remove_shared_memory(name, limit_to_session=False):
         n_deleted += 1
 
     if n_deleted == 0:
-        logging.debug("Did not find anything to delete fro %s" % name)
+        logging.debug("Did not find anything to delete for %s" % name)
 
 
 def remove_shared_memory_in_session():


### PR DESCRIPTION
See comments for notes on changes. Using named pipes to avoid writing large FASTAs, removing redundant deletion of temporary files, and splitting kmer-counting and genotyping tasks were the lowest hanging fruit.

Along with some tweaks to VM specs, this took the cost for running 10 30x 1kGP samples vs. HGSVC2 from [$4.87](https://app.terra.bio/#workspaces/broad-firecloud-dsde/sv-genotyping-and-imputation-1000G-high-coverage-2019/job_history/7fb6bc52-876c-4f96-969c-5ce9ae643b61) down to [$1.56](https://console.cloud.google.com/storage/browser/fc-99861591-dff6-4c11-8ba0-ed105c7f9d31/submissions/a3967fe2-61e2-42fe-ad93-43a3bf03100c). There is probably more room for improvement (e.g., speeding up VCF writing after genotyping).