### PR TITLE
Update bcftools to 1.21 again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     build-essential \
-    tabix \
-    bcftools \
     autoconf \
     zlib1g-dev \
     libncurses-dev \
@@ -25,6 +23,18 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.19.2/samtools-
     cd samtools-1.19.2 && \
     autoheader && \
     autoconf -Wno-syntax && \
+    ./configure && \
+    make && \
+    make install
+
+RUN mkdir /bcftools
+WORKDIR /bcftools
+RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2 && \
+    bzip2 -d bcftools-1.21.tar.bz2 && \
+    tar -xvf bcftools-1.21.tar && \
+    cd bcftools-1.21 && \
+    autoheader && \
+    autoconf && \
     ./configure && \
     make && \
     make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.19.2/samtools-
 ADD . /kage-lite
 WORKDIR /kage-lite
 
-RUN pip install numpy==1.23.5 scipy==1.10.0 dill==0.3.6 pandas==2.1.1 truvari==4.1.0 scikit-learn==1.3.1 matplotlib==3.8.0 pytest==8.0.0
+RUN pip install numpy==1.23.5 scipy==1.10.0 dill==0.3.6 pandas==2.1.1 truvari==4.1.0 scikit-learn==1.3.1 matplotlib==3.8.0 pytest==8.0.0 \
+                sharedarray==3.2.4 bionumpy==1.0.4 biopython==1.83 npstructures==0.2.16 cython==3.0.8 scikit-allel==1.3.7
 RUN pip install -e shared_memory_wrapper/ -e obgraph/ -e graph_kmer_index/ -e kmer_mapper/ -e kage/ -e lite_utils/
 
 ENV NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512_KNL,AVX512_KNM,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512CD,AVX512_SKX"


### PR DESCRIPTION
Pin packages to avoid broken test caused by scikit-allel transitive update of numpy.

Inadvertent update to numpy 1.26.4 caused the following error:

```
_________________ test_SampleChromosomeStructuralVariantKmers __________________

    def test_SampleChromosomeStructuralVariantKmers():
        graph = f'{test_resources_dir}/SampleChromosomeStructuralVariantKmers/inputs/test.chr1.obgraph.pkl'
        variant_to_nodes = f'{test_resources_dir}/SampleChromosomeStructuralVariantKmers/inputs/test.chr1.variant_to_nodes.pkl'
        linear_kmers_counter = f'{test_resources_dir}/SampleChromosomeStructuralVariantKmers/inputs/test.linear_kmers_counter.pkl'
        kmer_length = '31'
        chromosome = 'chr1'
        output = f'{output_dir}/test.{chromosome}.structural_variant_kmers.pkl'
        expected = f'{test_resources_dir}/SampleChromosomeStructuralVariantKmers/expected/test.{chromosome}.structural_variant_kmers.pkl'
    
>       graph_kmer_index_cli.run_argument_parser([
            'sample_kmers_from_structural_variants',
            '-k', kmer_length,
            '-g', graph,
            '-V', variant_to_nodes,
            '-i', linear_kmers_counter,
            '-o', output])

kage/tests/test_pipeline.py:336: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
graph_kmer_index/graph_kmer_index/command_line_interface.py:303: in run_argument_parser
    args.func(args)
graph_kmer_index/graph_kmer_index/command_line_interface.py:264: in sample_kmers_from_structural_variants_command
    kmers = sample_kmers_from_structural_variants(args.graph,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

graph = Obgraph
variant_to_nodes = <obgraph.variant_to_nodes.VariantToNodes object at 0x7f1c237d7730>
kmer_index_with_frequencies = <graph_kmer_index.kmer_counter.KmerCounter object at 0x7f1c237d63e0>
k = 31, max_frequency = 2

    def sample_kmers_from_structural_variants(graph, variant_to_nodes, kmer_index_with_frequencies, k, max_frequency=2):
        """"
        For every variant with big nodes,
        try to find kmers within the node with low frequency in kmer_index_with_frequencies
        """
    
        kmers_found = []
        nodes_found = []
        ref_offsets_found = []
    
        for ref_node, var_node  in variant_to_nodes:
            for node in (ref_node, var_node):
                if graph.get_node_size(node) > k + 5:
                    node_sequence = graph.get_numeric_node_sequence(node)
                    node_kmers = bionumpy_hash(node_sequence, k)
>                   kmer_frequencies = np.array([kmer_index_with_frequencies.get_frequency(k) for k in node_kmers])
E                   ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (69,) + inhomogeneous part.

graph_kmer_index/graph_kmer_index/structural_variants.py:22: ValueError
```