### PR TITLE
Increase recursion limit in obgraph to 20000 to avoid failures on large events.

### DIFF
--- a/obgraph/obgraph/graph.py
+++ b/obgraph/obgraph/graph.py
@@ -11,6 +11,8 @@ from .mutable_graph import MutableGraph
 from .nplist import NpList
 from .util import encode_chromosome
 
+import sys
+sys.setrecursionlimit(20000)
 
 class VariantNotFoundException(Exception):
     pass

--- a/obgraph/obgraph/mutable_graph.py
+++ b/obgraph/obgraph/mutable_graph.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+import sys
+sys.setrecursionlimit(20000)
 
 class MutableGraph:
     def __init__(self, nodes=None, node_sequences=None, edges=None, linear_ref_nodes=None, node_to_ref_offset=None, ref_offset_to_node=None, chromosome_start_nodes=None, allele_frequencies=None):


### PR DESCRIPTION
This hopefully fixes a limit that @danielben-isvy hit on chr1 when building an HPRC2 panel of 220 samples, initially at a ~49kb insertion at `chr1:12580200` but then also later on after removing that event. All other chromosomes completed successfully.

The limit of 20000 was simply cribbed from `graph_kmer_index/graph_kmer_index/kmer_finder.py`, which also increases the limit to that value from the python default value of 1000. This seems somewhat arbitrary, but hopefully we don't have to expose the limit anytime soon.