### PR TITLE
Revert bcftools 1.21 update again and add debugging for non-empty SNP message.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     build-essential \
+    tabix \
+    bcftools \
     autoconf \
     zlib1g-dev \
     libncurses-dev \
@@ -23,18 +25,6 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.19.2/samtools-
     cd samtools-1.19.2 && \
     autoheader && \
     autoconf -Wno-syntax && \
-    ./configure && \
-    make && \
-    make install
-
-RUN mkdir /bcftools
-WORKDIR /bcftools
-RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2 && \
-    bzip2 -d bcftools-1.21.tar.bz2 && \
-    tar -xvf bcftools-1.21.tar && \
-    cd bcftools-1.21 && \
-    autoheader && \
-    autoconf && \
     ./configure && \
     make && \
     make install

--- a/obgraph/obgraph/graph.py
+++ b/obgraph/obgraph/graph.py
@@ -371,7 +371,7 @@ class Graph:
             if len([n for n in possible_snp_node if self.get_node_size(n) > 0]) != 1:
                 logging.error("There should only be one non-empty SNP node")
                 logging.info("Found nodes: %s" % (possible_snp_node))
-                logging.info("prev node is %s, variant bases is %s" % (prev_node, variant_bases))
+                logging.info("prev node is %s, reference bases is %s, variant bases is %s, next ref pos is %s" % (prev_node, reference_bases, variant_bases, next_ref_pos))
                 raise Exception("error")
 
             potential_next = possible_snp_node[-1]  # Get last node, this will be the snp node if there are more nodes


### PR DESCRIPTION
bcftools 1.21 causes WDL-level errors (namely, there seems to be an issue with the header or fields in MakeSitesOnlyVcfAndNumpyVariants), so we will revert again. We also expand an error message that helps identify unnormalized variants in the panel that can cause failures in MakeChromosomeGraph, which we've hit in both HPRC+AoU1 and HPRC2.