### PR TITLE
Added coverage downscaling and changed order of Docker layers to cache pip installs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ RUN wget https://github.com/samtools/samtools/releases/download/1.19.2/samtools-
     make && \
     make install
 
+RUN pip install numpy==1.23.5 scipy==1.10.0 dill==0.3.6 pandas==2.1.1 truvari==4.1.0 scikit-learn==1.3.1 matplotlib==3.8.0 pytest==8.0.0 \
+                sharedarray==3.2.4 bionumpy==1.0.4 biopython==1.83 npstructures==0.2.16 cython==3.0.8 scikit-allel==1.3.7
+
 ADD . /kage-lite
 WORKDIR /kage-lite
 
-RUN pip install numpy==1.23.5 scipy==1.10.0 dill==0.3.6 pandas==2.1.1 truvari==4.1.0 scikit-learn==1.3.1 matplotlib==3.8.0 pytest==8.0.0 \
-                sharedarray==3.2.4 bionumpy==1.0.4 biopython==1.83 npstructures==0.2.16 cython==3.0.8 scikit-allel==1.3.7
 RUN pip install -e shared_memory_wrapper/ -e obgraph/ -e graph_kmer_index/ -e kmer_mapper/ -e kage/ -e lite_utils/
 
 ENV NPY_DISABLE_CPU_FEATURES="AVX512F,AVX512_KNL,AVX512_KNM,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512CD,AVX512_SKX"

--- a/kage/kage/command_line_interface.py
+++ b/kage/kage/command_line_interface.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from .util import vcf_pl_and_gl_header_lines, convert_string_genotypes_to_numeric_array, _write_genotype_debug_data
+from kage.genotyping.combination_model_genotyper import downscale_coverage
 
 logging.basicConfig(
     stream=sys.stderr,
@@ -55,6 +56,11 @@ def genotype(args):
         for i, count_model in enumerate(index.count_model):
             index.count_model[i].limit_to_n_individuals(args.limit_model_counts)
 
+    base = 30
+    if args.average_coverage > base:
+        logging.info("Downscaling coverage by %.3f / %d" % (args.average_coverage, base))
+        node_counts = downscale_coverage(config, node_counts, base)
+        logging.info("Set average coverage to base = %d" % (config.avg_coverage))
 
     genotyper = CombinationModelGenotyper(0, max_variant_id, node_counts, index, config=config)
     genotypes, probs, count_probs = genotyper.genotype()

--- a/kage/kage/genotyping/combination_model_genotyper.py
+++ b/kage/kage/genotyping/combination_model_genotyper.py
@@ -99,3 +99,14 @@ class CombinationModelGenotyper:
             variants[i].set_genotype(genotype, is_numeric=True)
 
         return self._predicted_genotypes, self._prob_correct
+
+def downscale_coverage(config, node_counts, base):
+    """
+    Downscales node counts and coverage. Used to not overestimate prob of genotypes when coverage is high.
+    """
+    factor = config.avg_coverage / base
+    logging.info("Before scale: %s" % node_counts)
+    node_counts = np.round(node_counts / factor)
+    logging.info("After scale: %s" % node_counts)
+    config.avg_coverage = base
+    return node_counts


### PR DESCRIPTION
Fix for v1.1 freeze callsets (3202 1kGP + 10k AoU AFR vs. AoU1+HPRC). See https://docs.google.com/presentation/d/1KfQsmFPNRcIgDM_E92hR5r-Gsm0D1ree3QlP3MFLkAM/edit?usp=sharing